### PR TITLE
feature: Persistent Audience and availableAudience cleanup

### DIFF
--- a/src/components/experiment/experiment.js
+++ b/src/components/experiment/experiment.js
@@ -90,7 +90,7 @@ export default class Experiment extends React.Component {
     reduxAbTest:          Immutable.Map({}),
     id:                   null,
     name:                 null,
-    selector:             '',
+    selector:             null,
     defaultVariationName: null,
     dispatchActivate:     () => {},
     dispatchDeactivate:   () => {},
@@ -163,13 +163,14 @@ export default class Experiment extends React.Component {
   }
 
   getExperiment(reduxAbTest, selector, id, name) {
-    const key = selector && reduxAbTest.getIn(['availableExperiments', selector || id || name], null);
+    // Find the key of the currently available experiment
+    const key = reduxAbTest.getIn(['availableExperiments', selector || id || name], null);
     if (!key) {
       return null;
     }
-    const experiment = reduxAbTest.get('experiments').find(experiment => {
-      return getKey(experiment) === key;
-    }, null);
+    // Select the experiment from the redux store
+    const experiment = reduxAbTest.get('experiments').find(experiment => (getKey(experiment) === key), null);
+    // Return the resulting experiment
     return experiment;
   }
 

--- a/src/components/experiment/experiment.js
+++ b/src/components/experiment/experiment.js
@@ -163,19 +163,14 @@ export default class Experiment extends React.Component {
   }
 
   getExperiment(reduxAbTest, selector, id, name) {
-    const key = getKey(Immutable.Map({id, name}));
-    const experiments = reduxAbTest.getIn(['availableExperiments', selector || ''], Immutable.Map());
-    if (experiments.isEmpty()) {
+    const key = selector && reduxAbTest.getIn(['availableExperiments', selector || id || name], null);
+    if (!key) {
       return null;
     }
-    if (key && experiments.has(key)) {
-      return experiments.get(key);
-    }
-    // const active = experiments.values().filter( experiment => reduxAbTest.hasIn(['active', key]) ).first();
-    // if (active) {
-    //   return active;
-    // }
-    return experiments.values().first();
+    const experiment = reduxAbTest.get('experiments').find(experiment => {
+      return getKey(experiment) === key;
+    }, null);
+    return experiment;
   }
 
   isNotVariationChildren() {

--- a/src/components/experiment/experiment.test.js
+++ b/src/components/experiment/experiment.test.js
@@ -7,18 +7,20 @@ import { expect, renderContainer, spy } from 'test_helper';
 
 const reduxAbTest = initialState.merge({
   'availableExperiments': {
-    'Test-experimentName': {
-      name:       'Test-experimentName',
-      variations: [
-        { name: 'Original', weight: 10000 },
-        { name: 'Variation B', weight: 0 }
-      ],
+    '': {
+      'Test-experimentName': {
+        name:       'Test-experimentName',
+        variations: [
+          { name: 'Original', weight: 10000 },
+          { name: 'Variation B', weight: 0 }
+        ],
+      },
     },
   },
   'active': { 'Test-experimentName': 'Variation B' }
 });
 
-describe('(Component) src/components/experiment/experiment.js', () => {
+describe.skip('(Component) src/components/experiment/experiment.js', () => {
   let component;
   let props;
   let dispatchActivate;
@@ -137,16 +139,18 @@ describe('(Component) src/components/experiment/experiment.js', () => {
   describe('find by :selector', () => {
     const reduxAbTest = initialState.merge({
       availableExperiments: {
-        'Test-id': {
-          id:         'Test-id',
-          name:       'Test-experimentName',
-          component: {
-            key: 'Example component key selector',
+        'Example component key selector': {
+          'Test-id': {
+            id:         'Test-id',
+            name:       'Test-experimentName',
+            component: {
+              key: 'Example component key selector',
+            },
+            variations: [
+              { name: 'Original', weight: 10000 },
+              { name: 'Variation B', weight: 0 }
+            ],
           },
-          variations: [
-            { name: 'Original', weight: 10000 },
-            { name: 'Variation B', weight: 0 }
-          ],
         },
       },
       active: { 'Test-id': 'Variation B' },

--- a/src/components/experiment/experiment.test.js
+++ b/src/components/experiment/experiment.test.js
@@ -6,13 +6,22 @@ import { expect, renderContainer, spy } from 'test_helper';
 
 
 const reduxAbTest = initialState.merge({
+  experiments: [
+    {
+      name:       'Test-experimentName',
+      variations: [
+        { name: 'Original', weight: 10000 },
+        { name: 'Variation B', weight: 0 }
+      ],
+    },
+  ],
   'availableExperiments': {
     'Test-experimentName': 'Test-experimentName',
   },
   'active': { 'Test-experimentName': 'Variation B' }
 });
 
-describe.only('(Component) src/components/experiment/experiment.js', () => {
+describe('(Component) src/components/experiment/experiment.js', () => {
   let component;
   let props;
   let dispatchActivate;
@@ -87,6 +96,16 @@ describe.only('(Component) src/components/experiment/experiment.js', () => {
 
   describe('find by :id', () => {
     const reduxAbTest = initialState.merge({
+      experiments: [
+        {
+          id:         'Test-id',
+          name:       'Test-experimentName',
+          variations: [
+            { name: 'Original', weight: 10000 },
+            { name: 'Variation B', weight: 0 }
+          ],
+        },
+      ],
       'availableExperiments': { 'Test-id': 'Test-id' },
       'active': { 'Test-id': 'Variation B' }
     });
@@ -121,6 +140,19 @@ describe.only('(Component) src/components/experiment/experiment.js', () => {
 
   describe('find by :selector', () => {
     const reduxAbTest = initialState.merge({
+      experiments: [
+        {
+          id:         'Test-id',
+          name:       'Test-experimentName',
+          component: {
+            key: 'Example component key selector',
+          },
+          variations: [
+            { name: 'Original', weight: 10000 },
+            { name: 'Variation B', weight: 0 }
+          ],
+        },
+      ],
       availableExperiments: {
         'Example component key selector': 'Test-id',
       },

--- a/src/components/experiment/experiment.test.js
+++ b/src/components/experiment/experiment.test.js
@@ -7,20 +7,12 @@ import { expect, renderContainer, spy } from 'test_helper';
 
 const reduxAbTest = initialState.merge({
   'availableExperiments': {
-    '': {
-      'Test-experimentName': {
-        name:       'Test-experimentName',
-        variations: [
-          { name: 'Original', weight: 10000 },
-          { name: 'Variation B', weight: 0 }
-        ],
-      },
-    },
+    'Test-experimentName': 'Test-experimentName',
   },
   'active': { 'Test-experimentName': 'Variation B' }
 });
 
-describe.skip('(Component) src/components/experiment/experiment.js', () => {
+describe.only('(Component) src/components/experiment/experiment.js', () => {
   let component;
   let props;
   let dispatchActivate;
@@ -95,16 +87,7 @@ describe.skip('(Component) src/components/experiment/experiment.js', () => {
 
   describe('find by :id', () => {
     const reduxAbTest = initialState.merge({
-      'availableExperiments': {
-        'Test-id': {
-          id:         'Test-id',
-          name:       'Test-experimentName',
-          variations: [
-            { name: 'Original', weight: 10000 },
-            { name: 'Variation B', weight: 0 }
-          ],
-        },
-      },
+      'availableExperiments': { 'Test-id': 'Test-id' },
       'active': { 'Test-id': 'Variation B' }
     });
 
@@ -139,19 +122,7 @@ describe.skip('(Component) src/components/experiment/experiment.js', () => {
   describe('find by :selector', () => {
     const reduxAbTest = initialState.merge({
       availableExperiments: {
-        'Example component key selector': {
-          'Test-id': {
-            id:         'Test-id',
-            name:       'Test-experimentName',
-            component: {
-              key: 'Example component key selector',
-            },
-            variations: [
-              { name: 'Original', weight: 10000 },
-              { name: 'Variation B', weight: 0 }
-            ],
-          },
-        },
+        'Example component key selector': 'Test-id',
       },
       active: { 'Test-id': 'Variation B' },
       key_path: ['component', 'key'],

--- a/src/containers/experiment/experiment.test.js
+++ b/src/containers/experiment/experiment.test.js
@@ -41,8 +41,17 @@ describe('(Container) Experiment', () => {
       };
       const store = {
         reduxAbTest: initialState.merge({
+          experiments: [
+            {
+              name:       'Test-experimentName',
+              variations: [
+                { name: 'Original', weight: 10000 },
+                { name: 'Variation B', weight: 0 }
+              ]
+            }
+          ],
           availableExperiments: {
-            'Test-experimentName': ['Test-experimentName'],
+            'Test-experimentName': 'Test-experimentName',
           }
         })
       };

--- a/src/containers/experiment/experiment.test.js
+++ b/src/containers/experiment/experiment.test.js
@@ -42,13 +42,7 @@ describe('(Container) Experiment', () => {
       const store = {
         reduxAbTest: initialState.merge({
           availableExperiments: {
-            'Test-experimentName': {
-              name:       'Test-experimentName',
-              variations: [
-                { name: 'Original', weight: 10000 },
-                { name: 'Variation B', weight: 0 }
-              ]
-            }
+            'Test-experimentName': ['Test-experimentName'],
           }
         })
       };

--- a/src/module/index.js
+++ b/src/module/index.js
@@ -116,7 +116,7 @@ const reducers = {
     );
 
     return initialState.merge({
-      availableExperiments: availableExperiments({experiments, audience_path, audience, route, route_path}),
+      availableExperiments: availableExperiments({experiments, key_path, audience_path, audience, route, route_path}),
       experiments,
       audience,
       route,
@@ -136,13 +136,14 @@ const reducers = {
    * Set the Audience for the experiments
    */
   [SET_AUDIENCE]: (state, { payload }) => {
+    const audience       = payload.get('audience');
+    const audience_path  = state.get('audience_path');
     const route          = state.get('route');
     const route_path     = state.get('route_path');
-    const audience       = payload.get('audience');
+    const key_path       = state.get('key_path');
     const experiments    = state.get('experiments');
-    const audience_path  = state.get('audience_path');
     return state.merge({
-      availableExperiments: availableExperiments({experiments, audience_path, audience, route, route_path}),
+      availableExperiments: availableExperiments({experiments, key_path, audience_path, audience, route, route_path}),
       audience,
     });
   },
@@ -159,6 +160,7 @@ const reducers = {
       route,
       availableExperiments: availableExperiments({
         experiments:   state.get('experiments'),
+        key_path:      state.get('key_path'),
         audience_path: state.get('audience_path'),
         audience:      state.get('audience'),
         route,

--- a/src/module/index.js
+++ b/src/module/index.js
@@ -48,6 +48,7 @@ export const initialState = Immutable.fromJS({
   types_path:           ['win_action_types'],
   props_path:           ['componentProps'],
   audience_path:        ['audienceProps'],
+  persistent_path:      ['persistentExperience'],
   route_path:           ['routeProps'],
   win_action_types:     { /** Array of Redux Action Types */ },
 });
@@ -90,16 +91,17 @@ const reducers = {
    * LOAD the available experiments. and reset the state of the server
    */
   [LOAD]: (state, { payload }) => {
-    const key_path      = flattenCompact(payload.get('key_path',      state.get('key_path')));
-    const types_path    = flattenCompact(payload.get('types_path',    state.get('types_path')));
-    const props_path    = flattenCompact(payload.get('props_path',    state.get('props_path')));
-    const audience_path = flattenCompact(payload.get('audience_path', state.get('audience_path')));
-    const route_path    = flattenCompact(payload.get('route_path',    state.get('route_path')));
-    const experiments   = payload.has('experiments') ? payload.get('experiments') : state.get('experiments');
-    const active        = payload.has('active')      ? payload.get('active')      : state.get('active');
-    const winners       = payload.has('winners')     ? payload.get('winners')     : state.get('winners');
-    const audience      = payload.has('audience')    ? payload.get('audience')    : state.get('audience');
-    const route         = payload.has('route')       ? payload.get('route')       : state.get('route');
+    const key_path        = flattenCompact(payload.get('key_path',      state.get('key_path')));
+    const types_path      = flattenCompact(payload.get('types_path',    state.get('types_path')));
+    const props_path      = flattenCompact(payload.get('props_path',    state.get('props_path')));
+    const audience_path   = flattenCompact(payload.get('audience_path', state.get('audience_path')));
+    const persistent_path = flattenCompact(payload.get('persistent_path', state.get('persistent_path')));
+    const route_path      = flattenCompact(payload.get('route_path',    state.get('route_path')));
+    const experiments     = payload.has('experiments') ? payload.get('experiments') : state.get('experiments');
+    const active          = payload.has('active')      ? payload.get('active')      : state.get('active');
+    const winners         = payload.has('winners')     ? payload.get('winners')     : state.get('winners');
+    const audience        = payload.has('audience')    ? payload.get('audience')    : state.get('audience');
+    const route           = payload.has('route')       ? payload.get('route')       : state.get('route');
 
     const win_action_types = experiments.reduce(
       (map, experiment) => {
@@ -116,7 +118,16 @@ const reducers = {
     );
 
     return initialState.merge({
-      availableExperiments: availableExperiments({experiments, key_path, audience_path, audience, route, route_path}),
+      availableExperiments: availableExperiments({
+        experiments,
+        key_path,
+        active,
+        persistent_path,
+        audience_path,
+        audience,
+        route,
+        route_path,
+      }),
       experiments,
       audience,
       route,
@@ -125,6 +136,7 @@ const reducers = {
       key_path,
       types_path,
       props_path,
+      persistent_path,
       audience_path,
       route_path,
       win_action_types
@@ -137,13 +149,17 @@ const reducers = {
    */
   [SET_AUDIENCE]: (state, { payload }) => {
     const audience       = payload.get('audience');
-    const audience_path  = state.get('audience_path');
-    const route          = state.get('route');
-    const route_path     = state.get('route_path');
-    const key_path       = state.get('key_path');
-    const experiments    = state.get('experiments');
     return state.merge({
-      availableExperiments: availableExperiments({experiments, key_path, audience_path, audience, route, route_path}),
+      availableExperiments: availableExperiments({
+        experiments:     state.get('experiments'),
+        key_path:        state.get('key_path'),
+        active:          state.get('active'),
+        persistent_path: state.get('persistent_path'),
+        audience_path:   state.get('audience_path'),
+        route:           state.get('route'),
+        route_path:      state.get('route_path'),
+        audience,
+      }),
       audience,
     });
   },

--- a/src/module/index.test.js
+++ b/src/module/index.test.js
@@ -314,7 +314,7 @@ describe('(Redux) src/module/index.js', () => {
       newState: initialState.merge({
         active:               { "Test-Name": "Variation #A" },
         experiments:          [ experiment ],
-        availableExperiments: { '' : ["Test-Name"] },
+        availableExperiments: { 'Test-Name' : "Test-Name" },
       }),
     });
 

--- a/src/module/index.test.js
+++ b/src/module/index.test.js
@@ -314,7 +314,7 @@ describe('(Redux) src/module/index.js', () => {
       newState: initialState.merge({
         active:               { "Test-Name": "Variation #A" },
         experiments:          [ experiment ],
-        availableExperiments: { "Test-Name": experiment },
+        availableExperiments: { '' : ["Test-Name"] },
       }),
     });
 

--- a/src/utils/available-experiments.js
+++ b/src/utils/available-experiments.js
@@ -84,20 +84,26 @@ export const matchesRoute = (route, routeProps) => {
  * 1. 'route' matches the given experiment.getIn(route_path)
  * 2. 'audience' matches the given experiment.getIn(audience_path)
  */
-const availableExperiments = ({experiments, audience_path, route_path, audience, route}) => {
+const availableExperiments = ({experiments, key_path, audience_path, route_path, audience, route}) => {
   // Filter by routes
-  let output = experiments.filter(
+  experiments = experiments.filter(
     (experiment) => matchesRoute(route, experiment.getIn(route_path, null))
   );
 
   // Filter by audience
-  output = output.filter(
+  experiments = experiments.filter(
     (experiment) => matchesAudience(audience, experiment.getIn(audience_path, null))
   );
 
-  // Map the results together into a hash of `key` => `experiment`
-  output = output.reduce(
-    (hash, experiment) => hash.set(getKey(experiment), experiment),
+  // Map the results together into a hash of `selector` => `key` => `experiment`
+  const output = experiments.reduce(
+    (hash, experiment) => {
+      const selector = experiment.getIn(key_path, '');
+      const key      = getKey(experiment);
+      let list     = hash.get(selector, Immutable.List());
+      list = list.push(key);
+      return hash.set(selector, list);
+    },
     Immutable.Map({}),
   );
   return output;

--- a/src/utils/available-experiments.test.js
+++ b/src/utils/available-experiments.test.js
@@ -265,7 +265,19 @@ describe('utils/available-experiments.js', () => {
     });
 
     const experiment_a = Immutable.fromJS({
-      name:          'Blank Audience',
+      key:           'BlankAudienceComponent',
+      name:          'Blank Audience 1',
+      audienceProps: {},
+      variations:    [
+        { name: 'Original', weight: 5000 },
+        { name: 'Variation #A', weight: 5000 },
+        { name: 'Variation #B', weight: 0 }
+      ],
+    });
+
+    const experiment_a2 = Immutable.fromJS({
+      key:           'BlankAudienceComponent',
+      name:          'Blank Audience 2',
       audienceProps: {},
       variations:    [
         { name: 'Original', weight: 5000 },
@@ -275,6 +287,7 @@ describe('utils/available-experiments.js', () => {
     });
 
     const experiment_b = Immutable.fromJS({
+      key:           'SimpleAudienceComponent',
       name:          'Simple Audience Type',
       audienceProps: {
         type: 'vip',
@@ -290,6 +303,7 @@ describe('utils/available-experiments.js', () => {
     });
 
     const experiment_c = Immutable.fromJS({
+      key:           'ComplexAudienceComponent',
       name:          'Complex Audience Type',
       audienceProps: {
         type:   'vip',
@@ -314,48 +328,90 @@ describe('utils/available-experiments.js', () => {
 
     it('undefined/blank matches any audience', () => {
       let output = availableExperiments({
+        key_path:      ['key'],
         audience:      Immutable.Map(),
         audience_path: ['audienceProps'],
-        experiments:   Immutable.List([experiment_0, experiment_a, experiment_b, experiment_c]),
+        experiments:   Immutable.List([experiment_0, experiment_a, experiment_a2, experiment_b, experiment_c]),
         route_path:    initialState.get('route_path'),
         route:         initialState.get('route'),
       });
       expect(output).to.be.an.instanceOf(Immutable.Map);
-      expect(Object.keys(output.toJS())).to.be.have.deep.equal([ 'No Audience', 'Blank Audience' ]);
+      expect(output.toJS()).to.deep.equal({
+        '': [
+          'No Audience',
+        ],
+        'BlankAudienceComponent': [
+          'Blank Audience 1', 'Blank Audience 2'
+        ],
+      });
+
 
       output = availableExperiments({
+        key_path:      ['key'],
         audience:      Immutable.fromJS({ type: 'new user' }),
         audience_path: ['audienceProps'],
-        experiments:   Immutable.List([experiment_0, experiment_a, experiment_b, experiment_c]),
+        experiments:   Immutable.List([experiment_0, experiment_a, experiment_a2, experiment_b, experiment_c]),
         route_path:    initialState.get('route_path'),
         route:         initialState.get('route'),
       });
       expect(output).to.be.an.instanceOf(Immutable.Map);
-      expect(Object.keys(output.toJS())).to.be.have.deep.equal([ 'No Audience', 'Blank Audience' ]);
+      expect(output.toJS()).to.deep.equal({
+        '': [
+          'No Audience',
+        ],
+        'BlankAudienceComponent': [
+          'Blank Audience 1', 'Blank Audience 2'
+        ],
+      });
     });
 
     it('matches vip', () => {
       const output = availableExperiments({
+        key_path:      ['key'],
         audience:      Immutable.fromJS({ type: 'vip' }),
         audience_path: ['audienceProps'],
-        experiments:   Immutable.List([experiment_0, experiment_a, experiment_b, experiment_c]),
+        experiments:   Immutable.List([experiment_0, experiment_a, experiment_a2, experiment_b, experiment_c]),
         route_path:    initialState.get('route_path'),
         route:         initialState.get('route').merge({pathName: '/magic'}),
       });
       expect(output).to.be.an.instanceOf(Immutable.Map);
-      expect(Object.keys(output.toJS())).to.be.have.deep.equal([ 'No Audience', 'Blank Audience', 'Simple Audience Type' ]);
+      expect(output.toJS()).to.deep.equal({
+        '': [
+          'No Audience',
+        ],
+        'BlankAudienceComponent': [
+          'Blank Audience 1', 'Blank Audience 2'
+        ],
+        'SimpleAudienceComponent': [
+          'Simple Audience Type',
+        ]
+      });
     });
 
     it('matches vip and orders', () => {
       const output = availableExperiments({
+        key_path:      ['key'],
         audience:      Immutable.fromJS({ type: 'vip', orders: 10, state: 'NY' }),
         audience_path: ['audienceProps'],
-        experiments:   Immutable.List([experiment_0, experiment_a, experiment_b, experiment_c]),
+        experiments:   Immutable.List([experiment_0, experiment_a, experiment_a2, experiment_b, experiment_c]),
         route_path:    initialState.get('route_path'),
         route:         initialState.get('route').merge({pathName: '/magic'}),
       });
       expect(output).to.be.an.instanceOf(Immutable.Map);
-      expect(Object.keys(output.toJS())).to.be.have.deep.equal([ 'No Audience', 'Blank Audience', 'Simple Audience Type', 'Complex Audience Type' ]);
+      expect(output.toJS()).to.deep.equal({
+        '': [
+          'No Audience',
+        ],
+        'BlankAudienceComponent': [
+          'Blank Audience 1', 'Blank Audience 2'
+        ],
+        'SimpleAudienceComponent': [
+          'Simple Audience Type',
+        ],
+        'ComplexAudienceComponent': [
+          'Complex Audience Type',
+        ],
+      });
     });
   });
 

--- a/src/utils/available-experiments.test.js
+++ b/src/utils/available-experiments.test.js
@@ -278,6 +278,7 @@ describe('utils/available-experiments.js', () => {
     const experiment_a2 = Immutable.fromJS({
       key:           'BlankAudienceComponent',
       name:          'Blank Audience 2',
+      persistentExperience: true,
       audienceProps: {},
       variations:    [
         { name: 'Original', weight: 5000 },
@@ -328,89 +329,78 @@ describe('utils/available-experiments.js', () => {
 
     it('undefined/blank matches any audience', () => {
       let output = availableExperiments({
-        key_path:      ['key'],
-        audience:      Immutable.Map(),
-        audience_path: ['audienceProps'],
-        experiments:   Immutable.List([experiment_0, experiment_a, experiment_a2, experiment_b, experiment_c]),
-        route_path:    initialState.get('route_path'),
-        route:         initialState.get('route'),
+        key_path:           ['key'],
+        active:             Immutable.Map(),
+        persistent_path:    ['persistentExperience'],
+        audience:           Immutable.Map(),
+        audience_path:      ['audienceProps'],
+        experiments:        Immutable.List([experiment_0, experiment_a, experiment_a2, experiment_b, experiment_c]),
+        route_path:         initialState.get('route_path'),
+        route:              initialState.get('route'),
       });
       expect(output).to.be.an.instanceOf(Immutable.Map);
       expect(output.toJS()).to.deep.equal({
-        '': [
-          'No Audience',
-        ],
-        'BlankAudienceComponent': [
-          'Blank Audience 1', 'Blank Audience 2'
-        ],
+        'No Audience': 'No Audience',
+        'BlankAudienceComponent': 'Blank Audience 1',
       });
+    });
 
-
-      output = availableExperiments({
-        key_path:      ['key'],
-        audience:      Immutable.fromJS({ type: 'new user' }),
-        audience_path: ['audienceProps'],
-        experiments:   Immutable.List([experiment_0, experiment_a, experiment_a2, experiment_b, experiment_c]),
-        route_path:    initialState.get('route_path'),
-        route:         initialState.get('route'),
+    it('undefined/blank gives preference to active w/persistentExperience', () => {
+      let output = availableExperiments({
+        key_path:           ['key'],
+        active:             Immutable.Map({
+          'Blank Audience 2': 'Variation #A',
+        }),
+        persistent_path:    ['persistentExperience'],
+        audience:           Immutable.fromJS({ type: 'new user' }),
+        audience_path:      ['audienceProps'],
+        experiments:        Immutable.List([experiment_0, experiment_a, experiment_a2, experiment_b, experiment_c]),
+        route_path:         initialState.get('route_path'),
+        route:              initialState.get('route'),
       });
       expect(output).to.be.an.instanceOf(Immutable.Map);
       expect(output.toJS()).to.deep.equal({
-        '': [
-          'No Audience',
-        ],
-        'BlankAudienceComponent': [
-          'Blank Audience 1', 'Blank Audience 2'
-        ],
+        'No Audience': 'No Audience',
+        'BlankAudienceComponent': 'Blank Audience 2',
       });
     });
 
     it('matches vip', () => {
       const output = availableExperiments({
-        key_path:      ['key'],
-        audience:      Immutable.fromJS({ type: 'vip' }),
-        audience_path: ['audienceProps'],
-        experiments:   Immutable.List([experiment_0, experiment_a, experiment_a2, experiment_b, experiment_c]),
-        route_path:    initialState.get('route_path'),
-        route:         initialState.get('route').merge({pathName: '/magic'}),
+        key_path:           ['key'],
+        active:             Immutable.Map(),
+        persistent_path:    ['persistentExperience'],
+        audience:           Immutable.fromJS({ type: 'vip' }),
+        audience_path:      ['audienceProps'],
+        experiments:        Immutable.List([experiment_0, experiment_a, experiment_a2, experiment_b, experiment_c]),
+        route_path:         initialState.get('route_path'),
+        route:              initialState.get('route').merge({pathName: '/magic'}),
       });
       expect(output).to.be.an.instanceOf(Immutable.Map);
       expect(output.toJS()).to.deep.equal({
-        '': [
-          'No Audience',
-        ],
-        'BlankAudienceComponent': [
-          'Blank Audience 1', 'Blank Audience 2'
-        ],
-        'SimpleAudienceComponent': [
-          'Simple Audience Type',
-        ]
+        'No Audience': 'No Audience',
+        'BlankAudienceComponent': 'Blank Audience 1',
+        'SimpleAudienceComponent': 'Simple Audience Type',
       });
     });
 
     it('matches vip and orders', () => {
       const output = availableExperiments({
-        key_path:      ['key'],
-        audience:      Immutable.fromJS({ type: 'vip', orders: 10, state: 'NY' }),
-        audience_path: ['audienceProps'],
-        experiments:   Immutable.List([experiment_0, experiment_a, experiment_a2, experiment_b, experiment_c]),
-        route_path:    initialState.get('route_path'),
-        route:         initialState.get('route').merge({pathName: '/magic'}),
+        key_path:           ['key'],
+        active:             Immutable.Map(),
+        persistent_path:    ['persistentExperience'],
+        audience:           Immutable.fromJS({ type: 'vip', orders: 10, state: 'NY' }),
+        audience_path:      ['audienceProps'],
+        experiments:        Immutable.List([experiment_0, experiment_a, experiment_a2, experiment_b, experiment_c]),
+        route_path:         initialState.get('route_path'),
+        route:              initialState.get('route').merge({pathName: '/magic'}),
       });
       expect(output).to.be.an.instanceOf(Immutable.Map);
       expect(output.toJS()).to.deep.equal({
-        '': [
-          'No Audience',
-        ],
-        'BlankAudienceComponent': [
-          'Blank Audience 1', 'Blank Audience 2'
-        ],
-        'SimpleAudienceComponent': [
-          'Simple Audience Type',
-        ],
-        'ComplexAudienceComponent': [
-          'Complex Audience Type',
-        ],
+        'No Audience': 'No Audience',
+        'BlankAudienceComponent': 'Blank Audience 1',
+        'SimpleAudienceComponent': 'Simple Audience Type',
+        'ComplexAudienceComponent': 'Complex Audience Type',
       });
     });
   });


### PR DESCRIPTION
- Refactored availableAudience to be a hash of `selector:string` => `key:string` instead of `selector:string` => `experiment:Immuable.Map`
- Added `persistentExperiment` feature.  Multiple experiments with the same selector & audience props can now run in parallel, preference is given to experiments that have been activated and have the `persistentExperiment` flag set to true
