### PR TITLE
Adding react-router v4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "shipit": "npm run build && npm publish && npm run clean",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
-  "version": "4.1.1",
+  "version": "5.0.0",
   "release": {
     "verifyConditions": {
       "path": "./test/release"

--- a/src/module/index.js
+++ b/src/module/index.js
@@ -177,6 +177,17 @@ const reducers = {
     const route = Immutable.fromJS({ path: (path || pathname), pathName: pathname, search, action, query, params });
     return computeAvailableExperiments(state.set('route', route));
   },
+  ['@@router/LOCATION_CHANGE']: (state, { payload }) => {
+    const { pathname, search, query } = payload;
+    const path = Immutable.fromJS(routes).map( route => route.get('path') ).filter( path => path ).last(null);
+    const route = Immutable.fromJS({
+      path: pathname,
+      pathName: pathname,
+      search,
+      query
+    });
+    return computeAvailableExperiments(state.set('route', route));
+  },
 
 
   /**


### PR DESCRIPTION
Added support for react-router 4.x redux actions.

This breaks previous support for react-router by removing `path`, `params`, and  `action`.
